### PR TITLE
Validation bug

### DIFF
--- a/api/models/userModel.ts
+++ b/api/models/userModel.ts
@@ -1,75 +1,95 @@
-import mongoose, { Document } from "mongoose";
+import mongoose, { ObjectId, Query } from "mongoose";
+import { UserDocument } from "../types/mongooseTypes";
 import validator from "validator";
 import bcrypt from "bcryptjs";
 
-interface UserDocument extends Document {
-	name: string;
-	email: string;
-	password: string;
-	passwordConfirm?: string;
-	agreeTerms: boolean;
-	role: string;
-	comparePasswords: (candidatePassword: string) => Promise<boolean>;
-}
+const userSchema = new mongoose.Schema<UserDocument>(
+    {
+        name: {
+            type: String,
+            required: [true, "Name is required."],
+            unique: true,
+            minlength: [3, "Name must be at least 3 characters long."],
+            maxlength: [50, "Name cannot be more than 50 characters long."],
+        },
+        email: {
+            type: String,
+            required: [true, "Email is required."],
+            lowercase: true,
+            unique: true,
+            validate: [validator.isEmail, "Please provide a valid email!"],
+        },
+        password: {
+            type: String,
+            required: [true, "Password is required."],
+            minlength: [8, "Password must be at least 8 characters long"],
+            match: [
+                /^(?=.*[!@#$%^&*])/,
+                "Password must contain at least one special character (!@#$%^&*)",
+            ],
+            select: false, //Does not read it when getting the data from the DB
+        },
+        passwordConfirm: {
+            type: String, // set type to String (fix)
+            required: [true, "PasswordConfirm is required."],
+            validate: {
+                validator: function (this: UserDocument, pass: string): boolean {
+                    return pass === this.password;
+                },
+            },
+        },
+        agreeTerms: {
+            type: Boolean,
+            required: [
+                true,
+                "Please agree to the terms and conditions to use this service!",
+            ],
+            validate: {
+                validator: function(v: boolean): boolean {
+                    return v === true;
+                },
+                message: "You must agree to the terms and conditions!"
+            },
+        },
+        role: {
+            type: String,
+            enum: ["admin", "user"],
+            default: "user",
+        },
+    },
+    {
+        timestamps: true,
+    }
+);
 
-const userSchema = new mongoose.Schema<UserDocument>({
-	name: {
-		type: String,
-		required: [true, "Name is required."],
-		unique: true,
-	},
-	email: {
-		type: String,
-		required: [true, "Email is required."],
-		lowercase: true,
-		unique: true,
-		validate: [validator.isEmail, "Please provide a valid email!"],
-	},
-	password: {
-		type: String,
-		required: [true, "Password is required."],
-		minlength: [8, "Password must be at least 8 characters long"],
-		match: [
-			/^(?=.*[!@#$%^&*])/,
-			"Password must contain at least one special character (!@#$%^&*)",
-		],
-		select: false,
-	},
-	passwordConfirm: {
-		type: String,
-		required: [true, "Please confirm your password."],
-		validate: {
-			validator: function(this: UserDocument, el: string): boolean {
-				// only works on CREATE and SAVE
-				return el === this.password;
-			},
-			message: 'Passwords are not the same!'
-		}
-	},
-	agreeTerms: {
-		type: Boolean,
-		required: [true, "Please agree to the terms and conditions to use this service!"],
-		validate: [(v: boolean) => v, "You must agree to the terms and conditions!"],
-	},
-	role: {
-		type: String,
-		enum: ["admin", "user"],
-		default: "user",
-	},
-}, {
-	timestamps: true,
+//Before "save", hash the password with bcrypt
+userSchema.pre("save", async function (next) {
+    //TODO: add only run if password has been modified
+    if (!this.isModified("password")) {
+        return next();
+    }
+
+    this.password = await bcrypt.hash(this.password, 12);
+
+    //After the password it compared and verified, remove the plaintext "confirm password"
+    this.passwordConfirm = undefined;
+    next();
 });
 
-userSchema.pre('save', async function(next) {
-	if (!this.isModified('password')) return next();
+// Funkar ej pga typ  :((((((
+/* userSchema.post("find", function (next) {
+    this._id = this._id.toString();
+    next();
+}); */
 
-	this.password = await bcrypt.hash(this.password, 12);
-	this.passwordConfirm = undefined;
-	next();
-});
-
-userSchema.methods.comparePasswords = async function(candidatePassword: string) {
-	return await bcrypt.compare(candidatePassword, this.password);
+userSchema.methods.comparePasswords = async function (
+    currentPassword: string,
+    originalPassword: string
+) {
+    return await bcrypt.compare(currentPassword, originalPassword);
 };
 
-export default mongoose.model<UserDocument>("User", userSchema);
+// type User = mongoose.InferSchemaType<typeof userSchema>;
+
+const User = mongoose.model("User", userSchema);
+export default User;

--- a/api/models/userModel.ts
+++ b/api/models/userModel.ts
@@ -1,94 +1,75 @@
-import mongoose, { ObjectId, Query } from "mongoose";
-import { UserDocument } from "../types/mongooseTypes";
+import mongoose, { Document } from "mongoose";
 import validator from "validator";
 import bcrypt from "bcryptjs";
 
-const userSchema = new mongoose.Schema<UserDocument>(
-	{
-		name: {
-			type: String,
-			required: [true, "Name is required."],
-			unique: true,
-		},
-		email: {
-			type: String,
-			required: [true, "Email is required."],
-			lowercase: true,
-			unique: true,
-			validate: [validator.isEmail, "Please provide a valid email!"],
-		},
-		password: {
-			type: String,
-			required: [true, "Password is required."],
-			minlength: [8, "Password must be at least 8 characters long"],
-			match: [
-				/^(?=.*[!@#$%^&*])/,
-				"Password must contain at least one special character (!@#$%^&*)",
-			],
-			select: false, //Does not read it when getting the data from the DB
-		},
-		passwordConfirm: {
-			type: {}, //set 'any' type FIXME!
-			required: [true, "PasswordConfirm is required."],
+interface UserDocument extends Document {
+	name: string;
+	email: string;
+	password: string;
+	passwordConfirm?: string;
+	agreeTerms: boolean;
+	role: string;
+	comparePasswords: (candidatePassword: string) => Promise<boolean>;
+}
 
-			validate: {
-				validator: function (this: UserDocument, pass: string): boolean {
-					return pass === this.password;
-				},
-			},
-		},
-		agreeTerms: {
-			type: Boolean,
-			required: [
-				true,
-				"Please agree to the terms and conditions to use this service!",
-			],
-			validate: {
-				validator: function(v: boolean): boolean {
-					return v === true;
-				},
-				message: "You must agree to the terms and conditions!"
-			},
-		},
-		role: {
-			type: String,
-			enum: ["admin", "user"],
-			default: "user",
-		},
+const userSchema = new mongoose.Schema<UserDocument>({
+	name: {
+		type: String,
+		required: [true, "Name is required."],
+		unique: true,
 	},
-	{
-		timestamps: true,
-	}
-);
+	email: {
+		type: String,
+		required: [true, "Email is required."],
+		lowercase: true,
+		unique: true,
+		validate: [validator.isEmail, "Please provide a valid email!"],
+	},
+	password: {
+		type: String,
+		required: [true, "Password is required."],
+		minlength: [8, "Password must be at least 8 characters long"],
+		match: [
+			/^(?=.*[!@#$%^&*])/,
+			"Password must contain at least one special character (!@#$%^&*)",
+		],
+		select: false,
+	},
+	passwordConfirm: {
+		type: String,
+		required: [true, "Please confirm your password."],
+		validate: {
+			validator: function(this: UserDocument, el: string): boolean {
+				// only works on CREATE and SAVE
+				return el === this.password;
+			},
+			message: 'Passwords are not the same!'
+		}
+	},
+	agreeTerms: {
+		type: Boolean,
+		required: [true, "Please agree to the terms and conditions to use this service!"],
+		validate: [(v: boolean) => v, "You must agree to the terms and conditions!"],
+	},
+	role: {
+		type: String,
+		enum: ["admin", "user"],
+		default: "user",
+	},
+}, {
+	timestamps: true,
+});
 
-//Before "save", hash the password with bcrypt
-userSchema.pre("save", async function (next) {
-	//TODO: add only run if password has been modified
-	if (!this.isModified("password")) {
-		return next();
-	}
+userSchema.pre('save', async function(next) {
+	if (!this.isModified('password')) return next();
 
 	this.password = await bcrypt.hash(this.password, 12);
-
-	//After the password it compared and verified, remove the plaintext "confirm password"
 	this.passwordConfirm = undefined;
 	next();
 });
 
-// Funkar ej pga typ  :((((((
-/* userSchema.post("find", function (next) {
-	this._id = this._id.toString();
-	next();
-}); */
-
-userSchema.methods.comparePasswords = async function (
-	currentPassword: string,
-	originalPassword: string
-) {
-	return await bcrypt.compare(currentPassword, originalPassword);
+userSchema.methods.comparePasswords = async function(candidatePassword: string) {
+	return await bcrypt.compare(candidatePassword, this.password);
 };
 
-// type User = mongoose.InferSchemaType<typeof userSchema>;
-
-const User = mongoose.model("User", userSchema);
-export default User;
+export default mongoose.model<UserDocument>("User", userSchema);


### PR DESCRIPTION
1. 'name' -fältet: JLa till 'minlength' och 'maxlength' egenskaper för validering. 
2. 'passwordConfirm': böt typ till String. Var {} tidigare, vilket typescript klagade på, detta fält ska vara en sträng som matchar lösenordet. 
3. Skapar en 'User' -modell från 'userSchema' 

Övriga upplysningar: 

4. Flyttade UserDocument för att få klarhet genom att hålla all information på en och samma plats, går såklart att flytta tillbaka när modulen är helt klar. 
5. userSchema, som jobbar med UserDocument, ger en struktur av userprofilen i databasen. Varje fält i schemat motsvarar en egenskap i de användardokument som kommer att skapas. Schemat innehåller också olika alternativ för varje fält såsom typ, om det är obligatoriskt och andra valideringsregler.
6. Hashar lösenord med hjälp av bcrypt, denna körs innan lösenordet sparas.
7. Jämför lösenord, sträng mot sträng, efter att bcrypt har krypterat lösenordet:

userSchema.methods.comparePasswords = async function (
    currentPassword: string,
    originalPassword: string
) {
    return await bcrypt.compare(currentPassword, originalPassword);
};

8. Skapar en user när alla fält är ifyllda.


Slutligen, validatorn: validator: function(v: boolean): boolean {
                    return v === true;
                },
                
                
                
Validator är en del av MongoDB egna verktyg för objektmodellering. Funktionen tar emot ett värde som parameter och returnerar antingen true eller false. Funktionen används för att se till att värdet för det fältet uppfyller ett visst villkor, i det här fallet om användaren har accepterat villkoren.

Parametern "v" representerar värdet av agreeTerms-fältet i databasen och går såklart att byta till något tydligare.
I det här fallet måste värdet vara true (det vill säga, användaren måste ha godkänt villkoren) för att valideringen ska lyckas.

Finns att läsa mer här:
https://www.mongodb.com/docs/manual/core/schema-validation/